### PR TITLE
Add Spring Boot job hunter service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.idea/
+*.iml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
 # jobshunter
+
+Aplicatie Java 25 (Spring Boot) care iti citeste CV-ul dintr-un PDF, ruleaza zilnic cautari automate de joburi pe internet si iti trimite rezultatele pe WhatsApp.
+
+## Functionalitati
+- **Parser de CV PDF** bazat pe Apache PDFBox; extrage textul si cuvintele cheie relevante.
+- **Cautator REST** care apeleaza API-ul public [Remotive](https://remotive.com/api/remote-jobs) in functie de promptul tau.
+- **Motor de potrivire** ce prioritizeaza joburile compatibile cu tehnologiile din CV-ul tau.
+- **Programator zilnic** configurabil prin cron (`jobshunter.scheduler.cron`).
+- **Notificare WhatsApp** via Twilio (cu fallback la loguri atunci cand credidentialele lipsesc).
+- **REST API** pentru a porni manual o cautare si a verifica ultimul rezultat.
+
+## Cerinte
+- Java 25 (OpenJDK 25)
+- Maven 3.9+
+- Un fisier `cv.pdf` plasat in radacina proiectului (sau configurezi o alta cale).
+- Optional: cont Twilio cu canal WhatsApp (SID, Token, numar "from", numar "to").
+
+## Configurare
+Aplicatia foloseste `application.yml` si/sau variabile de mediu:
+
+```yaml
+jobshunter:
+  prompt: "Senior Java developer remote"
+  cv-path: "cv.pdf"
+  scheduler:
+    cron: "0 0 9 * * *"   # ora 09:00 zilnic
+  whatsapp:
+    account-sid: ${TWILIO_ACCOUNT_SID:}
+    auth-token: ${TWILIO_AUTH_TOKEN:}
+    from-number: ${TWILIO_WHATSAPP_FROM:}
+    to-number: ${TWILIO_WHATSAPP_TO:}
+```
+
+Variabile utile:
+
+```bash
+export TWILIO_ACCOUNT_SID="ACxxxxxxxx"
+export TWILIO_AUTH_TOKEN="secret"
+export TWILIO_WHATSAPP_FROM="whatsapp:+14155238886"
+export TWILIO_WHATSAPP_TO="whatsapp:+407xxxxxxxx"
+```
+
+## Rulare
+```bash
+mvn spring-boot:run
+```
+Aplicatia expune REST API pe `http://localhost:8080`:
+
+- `POST /api/job/search` – ruleaza imediat o cautare personalizata.
+  ```bash
+  curl -X POST http://localhost:8080/api/job/search \
+    -H 'Content-Type: application/json' \
+    -d '{"prompt": "Java 25 remote", "cvPath": "cv.pdf"}'
+  ```
+- `GET /api/job/status` – afiseaza ultimul rezultat salvat.
+
+Scheduler-ul zilnic foloseste promptul + calea salvate la ultima rulare manuala sau valorile din configuratie.
+
+## Dezvoltare si Testare
+```bash
+mvn verify
+```
+Testele includ crearea dinamica a unui PDF temporar pentru a verifica parserul si algoritmul de matching.
+
+## Flux WhatsApp
+1. Parserul citeste `cv.pdf` si extrage pana la 25 de cuvinte cheie.
+2. API-ul Remotive intoarce joburi relevante pentru prompt.
+3. Motorul de potrivire sorteaza joburile pe baza cuvintelor cheie.
+4. `WhatsAppNotifier` trimite lista pe WhatsApp (sau in loguri daca lipsesc cheile Twilio).
+
+## Extensii posibile
+- Persistenta in baza de date pentru istoricul joburilor.
+- Integrare cu mai multe API-uri (LinkedIn, Indeed etc.).
+- UI web pentru editarea promptului si vizualizarea rezultatelor.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.jobshunter</groupId>
+    <artifactId>jobshunter</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>jobshunter</name>
+    <description>Daily automated job hunter based on your CV</description>
+
+    <properties>
+        <java.version>25</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twilio.sdk</groupId>
+            <artifactId>twilio</artifactId>
+            <version>10.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/main/java/com/jobshunter/JobshunterApplication.java
+++ b/src/main/java/com/jobshunter/JobshunterApplication.java
@@ -1,0 +1,17 @@
+package com.jobshunter;
+
+import com.jobshunter.config.ApplicationProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties(ApplicationProperties.class)
+public class JobshunterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(JobshunterApplication.class, args);
+    }
+}

--- a/src/main/java/com/jobshunter/config/ApplicationProperties.java
+++ b/src/main/java/com/jobshunter/config/ApplicationProperties.java
@@ -1,0 +1,104 @@
+package com.jobshunter.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jobshunter")
+public class ApplicationProperties {
+
+    /**
+     * Prompt describing the perfect job for the candidate.
+     */
+    private String prompt = "Software developer role working with Java";
+
+    /**
+     * Path to the PDF CV file.
+     */
+    private String cvPath = "cv.pdf";
+
+    private Scheduler scheduler = new Scheduler();
+
+    private WhatsApp whatsapp = new WhatsApp();
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public void setPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public String getCvPath() {
+        return cvPath;
+    }
+
+    public void setCvPath(String cvPath) {
+        this.cvPath = cvPath;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public WhatsApp getWhatsapp() {
+        return whatsapp;
+    }
+
+    public void setWhatsapp(WhatsApp whatsapp) {
+        this.whatsapp = whatsapp;
+    }
+
+    public static class Scheduler {
+        private String cron = "0 0 9 * * *"; // 09:00 every day
+
+        public String getCron() {
+            return cron;
+        }
+
+        public void setCron(String cron) {
+            this.cron = cron;
+        }
+    }
+
+    public static class WhatsApp {
+        private String accountSid = System.getenv("TWILIO_ACCOUNT_SID");
+        private String authToken = System.getenv("TWILIO_AUTH_TOKEN");
+        private String fromNumber = System.getenv("TWILIO_WHATSAPP_FROM");
+        private String toNumber = System.getenv("TWILIO_WHATSAPP_TO");
+
+        public String getAccountSid() {
+            return accountSid;
+        }
+
+        public void setAccountSid(String accountSid) {
+            this.accountSid = accountSid;
+        }
+
+        public String getAuthToken() {
+            return authToken;
+        }
+
+        public void setAuthToken(String authToken) {
+            this.authToken = authToken;
+        }
+
+        public String getFromNumber() {
+            return fromNumber;
+        }
+
+        public void setFromNumber(String fromNumber) {
+            this.fromNumber = fromNumber;
+        }
+
+        public String getToNumber() {
+            return toNumber;
+        }
+
+        public void setToNumber(String toNumber) {
+            this.toNumber = toNumber;
+        }
+    }
+}

--- a/src/main/java/com/jobshunter/model/CvProfile.java
+++ b/src/main/java/com/jobshunter/model/CvProfile.java
@@ -1,0 +1,7 @@
+package com.jobshunter.model;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+public record CvProfile(Path source, String text, Set<String> keywords) {
+}

--- a/src/main/java/com/jobshunter/model/JobHuntSummary.java
+++ b/src/main/java/com/jobshunter/model/JobHuntSummary.java
@@ -1,0 +1,8 @@
+package com.jobshunter.model;
+
+import java.util.List;
+
+public record JobHuntSummary(String prompt,
+                              String cvPath,
+                              List<JobOpportunity> jobsFound) {
+}

--- a/src/main/java/com/jobshunter/model/JobOpportunity.java
+++ b/src/main/java/com/jobshunter/model/JobOpportunity.java
@@ -1,0 +1,15 @@
+package com.jobshunter.model;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record JobOpportunity(
+        String title,
+        String company,
+        String location,
+        URI url,
+        OffsetDateTime publishedAt,
+        List<String> tags,
+        String description) {
+}

--- a/src/main/java/com/jobshunter/model/JobSearchRequest.java
+++ b/src/main/java/com/jobshunter/model/JobSearchRequest.java
@@ -1,0 +1,8 @@
+package com.jobshunter.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JobSearchRequest(
+        @NotBlank(message = "Prompt cannot be blank") String prompt,
+        @NotBlank(message = "Path to the CV PDF is required") String cvPath) {
+}

--- a/src/main/java/com/jobshunter/service/CvParserService.java
+++ b/src/main/java/com/jobshunter/service/CvParserService.java
@@ -1,0 +1,51 @@
+package com.jobshunter.service;
+
+import com.jobshunter.model.CvProfile;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class CvParserService {
+
+    private static final Logger log = LoggerFactory.getLogger(CvParserService.class);
+
+    public CvProfile parse(Path pdfPath) {
+        if (!Files.exists(pdfPath)) {
+            throw new IllegalArgumentException("CV file not found: " + pdfPath);
+        }
+
+        try (PDDocument document = PDDocument.load(pdfPath.toFile())) {
+            String text = new PDFTextStripper().getText(document);
+            Set<String> keywords = extractKeywords(text);
+            log.info("Extracted {} keywords from CV", keywords.size());
+            return new CvProfile(pdfPath, text, keywords);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse CV file", e);
+        }
+    }
+
+    private Set<String> extractKeywords(String text) {
+        Map<String, Long> counts = Arrays.stream(text.split("[^A-Za-z]+"))
+                .map(String::toLowerCase)
+                .filter(word -> word.length() > 3)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        return counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(25)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/jobshunter/service/JobHuntOrchestrator.java
+++ b/src/main/java/com/jobshunter/service/JobHuntOrchestrator.java
@@ -1,0 +1,69 @@
+package com.jobshunter.service;
+
+import com.jobshunter.config.ApplicationProperties;
+import com.jobshunter.model.CvProfile;
+import com.jobshunter.model.JobHuntSummary;
+import com.jobshunter.model.JobOpportunity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+public class JobHuntOrchestrator {
+
+    private static final Logger log = LoggerFactory.getLogger(JobHuntOrchestrator.class);
+
+    private final CvParserService cvParserService;
+    private final RemoteJobApiClient remoteJobApiClient;
+    private final JobMatcherService jobMatcherService;
+    private final WhatsAppNotifier whatsAppNotifier;
+
+    private final AtomicReference<String> promptRef;
+    private final AtomicReference<Path> cvPathRef;
+    private final AtomicReference<JobHuntSummary> lastRun = new AtomicReference<>();
+
+    public JobHuntOrchestrator(ApplicationProperties properties,
+                               CvParserService cvParserService,
+                               RemoteJobApiClient remoteJobApiClient,
+                               JobMatcherService jobMatcherService,
+                               WhatsAppNotifier whatsAppNotifier) {
+        this.cvParserService = cvParserService;
+        this.remoteJobApiClient = remoteJobApiClient;
+        this.jobMatcherService = jobMatcherService;
+        this.whatsAppNotifier = whatsAppNotifier;
+        this.promptRef = new AtomicReference<>(properties.getPrompt());
+        this.cvPathRef = new AtomicReference<>(Path.of(properties.getCvPath()));
+    }
+
+    @Scheduled(cron = "${jobshunter.scheduler.cron:0 0 9 * * *}")
+    public void scheduledRun() {
+        log.info("Running scheduled job hunt...");
+        runInternal(promptRef.get(), cvPathRef.get());
+    }
+
+    public JobHuntSummary runOnce(String prompt, String cvPath) {
+        promptRef.set(prompt);
+        Path path = Path.of(cvPath);
+        cvPathRef.set(path);
+        return runInternal(prompt, path);
+    }
+
+    public JobHuntSummary lastRun() {
+        return lastRun.get();
+    }
+
+    private JobHuntSummary runInternal(String prompt, Path cvPath) {
+        CvProfile profile = cvParserService.parse(cvPath);
+        List<JobOpportunity> jobs = remoteJobApiClient.search(prompt);
+        List<JobOpportunity> ranked = jobMatcherService.rank(profile, jobs);
+        whatsAppNotifier.send(ranked);
+        JobHuntSummary summary = new JobHuntSummary(prompt, cvPath.toString(), ranked);
+        lastRun.set(summary);
+        return summary;
+    }
+}

--- a/src/main/java/com/jobshunter/service/JobMatcherService.java
+++ b/src/main/java/com/jobshunter/service/JobMatcherService.java
@@ -1,0 +1,33 @@
+package com.jobshunter.service;
+
+import com.jobshunter.model.CvProfile;
+import com.jobshunter.model.JobOpportunity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class JobMatcherService {
+
+    public List<JobOpportunity> rank(CvProfile profile, List<JobOpportunity> jobs) {
+        Set<String> keywords = profile.keywords();
+        return jobs.stream()
+                .sorted((a, b) -> Integer.compare(score(b, keywords), score(a, keywords)))
+                .limit(10)
+                .collect(Collectors.toList());
+    }
+
+    private int score(JobOpportunity opportunity, Set<String> keywords) {
+        String haystack = (opportunity.description() + " " + opportunity.title()).toLowerCase(Locale.ROOT);
+        int matches = 0;
+        for (String keyword : keywords) {
+            if (haystack.contains(keyword.toLowerCase(Locale.ROOT))) {
+                matches++;
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/com/jobshunter/service/RemoteJobApiClient.java
+++ b/src/main/java/com/jobshunter/service/RemoteJobApiClient.java
@@ -1,0 +1,80 @@
+package com.jobshunter.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobshunter.model.JobOpportunity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RemoteJobApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(RemoteJobApiClient.class);
+    private static final URI BASE_URI = URI.create("https://remotive.com/api/remote-jobs");
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public List<JobOpportunity> search(String prompt) {
+        try {
+            String encoded = URLEncoder.encode(prompt, StandardCharsets.UTF_8);
+            URI uri = URI.create(BASE_URI + "?search=" + encoded);
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                log.warn("Job API returned {} - {}", response.statusCode(), response.body());
+                return List.of();
+            }
+            RemotiveResponse body = objectMapper.readValue(response.body(), RemotiveResponse.class);
+            return body.jobs == null ? List.of() : body.jobs.stream()
+                    .map(RemoteJobApiClient::toOpportunity)
+                    .collect(Collectors.toList());
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Job API request failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private static JobOpportunity toOpportunity(RemotiveJob job) {
+        return new JobOpportunity(
+                job.title,
+                job.companyName,
+                job.candidateRequiredLocation,
+                URI.create(job.url),
+                job.publicationDate,
+                job.tags == null ? List.of() : new ArrayList<>(job.tags),
+                job.description
+        );
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record RemotiveResponse(List<RemotiveJob> jobs) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record RemotiveJob(String title,
+                               String companyName,
+                               String candidateRequiredLocation,
+                               String url,
+                               OffsetDateTime publicationDate,
+                               List<String> tags,
+                               String description) {
+    }
+}

--- a/src/main/java/com/jobshunter/service/WhatsAppNotifier.java
+++ b/src/main/java/com/jobshunter/service/WhatsAppNotifier.java
@@ -1,0 +1,72 @@
+package com.jobshunter.service;
+
+import com.jobshunter.config.ApplicationProperties;
+import com.jobshunter.model.JobOpportunity;
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Service
+public class WhatsAppNotifier {
+
+    private static final Logger log = LoggerFactory.getLogger(WhatsAppNotifier.class);
+    private final ApplicationProperties properties;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    public WhatsAppNotifier(ApplicationProperties properties) {
+        this.properties = properties;
+    }
+
+    public void send(List<JobOpportunity> opportunities) {
+        if (opportunities.isEmpty()) {
+            log.info("No jobs found. Skipping WhatsApp notification.");
+            return;
+        }
+        if (!hasCredentials()) {
+            log.warn("Twilio credentials not configured. Printing jobs to the console instead.");
+            opportunities.forEach(job -> log.info("{} at {} - {}", job.title(), job.company(), job.url()));
+            return;
+        }
+
+        initializeTwilio();
+        String body = buildMessage(opportunities);
+        Message.creator(
+                        new com.twilio.type.PhoneNumber(properties.getWhatsapp().getToNumber()),
+                        new com.twilio.type.PhoneNumber(properties.getWhatsapp().getFromNumber()),
+                        body)
+                .create();
+        log.info("Sent WhatsApp notification with {} jobs", opportunities.size());
+    }
+
+    private boolean hasCredentials() {
+        ApplicationProperties.WhatsApp cfg = properties.getWhatsapp();
+        return cfg.getAccountSid() != null && !cfg.getAccountSid().isBlank()
+                && cfg.getAuthToken() != null && !cfg.getAuthToken().isBlank()
+                && cfg.getFromNumber() != null && !cfg.getFromNumber().isBlank()
+                && cfg.getToNumber() != null && !cfg.getToNumber().isBlank();
+    }
+
+    private void initializeTwilio() {
+        if (initialized.compareAndSet(false, true)) {
+            Twilio.init(properties.getWhatsapp().getAccountSid(), properties.getWhatsapp().getAuthToken());
+        }
+    }
+
+    private String buildMessage(List<JobOpportunity> opportunities) {
+        StringBuilder builder = new StringBuilder("🧠 Jobshunter – rezultate zilnice:\n");
+        opportunities.forEach(job -> builder
+                .append("• ")
+                .append(job.title())
+                .append(" @ ")
+                .append(job.company())
+                .append(" -> ")
+                .append(job.url())
+                .append('\n'));
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/jobshunter/web/JobSearchController.java
+++ b/src/main/java/com/jobshunter/web/JobSearchController.java
@@ -1,0 +1,38 @@
+package com.jobshunter.web;
+
+import com.jobshunter.model.JobHuntSummary;
+import com.jobshunter.model.JobSearchRequest;
+import com.jobshunter.service.JobHuntOrchestrator;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/job")
+public class JobSearchController {
+
+    private final JobHuntOrchestrator orchestrator;
+
+    public JobSearchController(JobHuntOrchestrator orchestrator) {
+        this.orchestrator = orchestrator;
+    }
+
+    @PostMapping("/search")
+    public JobHuntSummary search(@Valid @RequestBody JobSearchRequest request) {
+        return orchestrator.runOnce(request.prompt(), request.cvPath());
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<?> status() {
+        return Optional.ofNullable(orchestrator.lastRun())
+                .<ResponseEntity<?>>map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok(Map.of("message", "No search executed yet")));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8080
+
+jobshunter:
+  prompt: "Senior Java developer remote"
+  cv-path: "cv.pdf"
+  scheduler:
+    cron: "0 0 9 * * *"
+  whatsapp:
+    account-sid: ${TWILIO_ACCOUNT_SID:}
+    auth-token: ${TWILIO_AUTH_TOKEN:}
+    from-number: ${TWILIO_WHATSAPP_FROM:}
+    to-number: ${TWILIO_WHATSAPP_TO:}
+
+logging:
+  level:
+    root: INFO
+    com.jobshunter: DEBUG

--- a/src/test/java/com/jobshunter/service/CvParserServiceTest.java
+++ b/src/test/java/com/jobshunter/service/CvParserServiceTest.java
@@ -1,0 +1,39 @@
+package com.jobshunter.service;
+
+import com.jobshunter.model.CvProfile;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CvParserServiceTest {
+
+    private final CvParserService service = new CvParserService();
+
+    @Test
+    void parseExtractsKeywords() throws Exception {
+        Path tempPdf = Files.createTempFile("cv", ".pdf");
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage(PDRectangle.A4);
+            document.addPage(page);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.setFont(PDType1Font.HELVETICA, 12);
+                contentStream.beginText();
+                contentStream.newLineAtOffset(50, 750);
+                contentStream.showText("Java developer with Spring Boot, REST APIs and cloud experience.");
+                contentStream.endText();
+            }
+            document.save(tempPdf.toFile());
+        }
+
+        CvProfile profile = service.parse(tempPdf);
+        assertThat(profile.keywords()).contains("java", "spring");
+    }
+}

--- a/src/test/java/com/jobshunter/service/JobMatcherServiceTest.java
+++ b/src/test/java/com/jobshunter/service/JobMatcherServiceTest.java
@@ -1,0 +1,29 @@
+package com.jobshunter.service;
+
+import com.jobshunter.model.CvProfile;
+import com.jobshunter.model.JobOpportunity;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JobMatcherServiceTest {
+
+    private final JobMatcherService service = new JobMatcherService();
+
+    @Test
+    void ranksJobsByKeywordMatches() {
+        CvProfile profile = new CvProfile(null, "", Set.of("java", "cloud", "spring"));
+        JobOpportunity a = new JobOpportunity("Java Developer", "ACME", "Remote",
+                URI.create("https://example.com/a"), OffsetDateTime.now(), List.of(), "Java spring microservices");
+        JobOpportunity b = new JobOpportunity("Python Developer", "ACME", "Remote",
+                URI.create("https://example.com/b"), OffsetDateTime.now(), List.of(), "python data science");
+
+        List<JobOpportunity> ranked = service.rank(profile, List.of(b, a));
+        assertThat(ranked.get(0)).isEqualTo(a);
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap a Java 25 / Spring Boot application that parses a PDF CV, runs job searches via the Remotive API, matches the results against extracted keywords and notifies the user on WhatsApp
- expose REST endpoints plus a configurable scheduler that reuse the most recent prompt/CV path and log the jobs when WhatsApp credentials are missing
- document how to configure, run and test the service and add unit tests for the CV parser and matcher

## Testing
- `mvn -q verify` *(fails: Maven Central (https://repo1.maven.org/maven2/) responds with HTTP 403, so plugins/dependencies cannot be downloaded in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691986045458832f9bc15d9bc5f6b2df)