### PR TITLE
Create centered single-column login layout

### DIFF
--- a/application/src/main/resources/static/index.html
+++ b/application/src/main/resources/static/index.html
@@ -15,12 +15,6 @@
 
   const h = React.createElement;
 
-  const Section = ({title, children}) =>
-      h('section', {className: 'card'},
-          h('h2', null, title),
-          children
-      );
-
   function useApi(baseUrl, token, logMessage) {
     return useMemo(() => ({
       async call(path, {method = 'GET', body, headers = {}} = {}) {
@@ -50,30 +44,16 @@
   }
 
   const App = () => {
-    const [baseUrl, setBaseUrl] = useState('http://localhost:8081');
-    const [token, setToken] = useState('');
     const [status, setStatus] = useState('Ready');
-    const [registerForm, setRegisterForm] = useState({username: '', email: '', password: '', phoneNumber: ''});
     const [loginForm, setLoginForm] = useState({username: '', password: ''});
-    const [me, setMe] = useState(null);
-    const [jobs, setJobs] = useState([]);
-    const [notifyWhatsApp, setNotifyWhatsApp] = useState(false);
+    const [token, setToken] = useState('');
 
     const logMessage = (msg) => setStatus(msg);
-    const api = useApi(baseUrl.trim().replace(/\/$/, ''), token, logMessage);
-
-    const handleRegister = async (e) => {
-      e.preventDefault();
-      try {
-        const res = await api.call('/api/auth/register', {method: 'POST', body: registerForm});
-        logMessage(`Registered. Verification token: ${res.verificationToken || 'check logs'}`);
-      } catch (err) {
-        logMessage(err.message);
-      }
-    };
+    const api = useApi('http://localhost:8081', token, logMessage);
 
     const handleLogin = async (e) => {
       e.preventDefault();
+      logMessage('Logging in...');
       try {
         const res = await api.call('/api/auth/login', {method: 'POST', body: loginForm});
         setToken(res.token);
@@ -83,129 +63,32 @@
       }
     };
 
-    const handleMe = async () => {
-      try {
-        const res = await api.call('/api/user/me');
-        setMe(res);
-      } catch (err) {
-        logMessage(err.message);
-      }
-    };
-
-    const handleSearch = async () => {
-      try {
-        const res = await api.call(`/api/user/search?notifyOnWhatsApp=${notifyWhatsApp}`, {method: 'POST'});
-        setJobs((res && res.jobsFound) || []);
-        logMessage(`Found ${(res && res.jobsFound && res.jobsFound.length) || 0} jobs`);
-      } catch (err) {
-        logMessage(err.message);
-      }
-    };
-
-    return h('div', {className: 'page'},
-        h('header', null,
-            h('h1', null, 'JobsHunter'),
-            h('p', null, 'Lightweight UI to hit your backend API (deployable to Vercel as static React).')
-        ),
-        h(Section, {title: 'Backend settings'},
-            h('label', {className: 'field'},
-                h('span', null, 'API base URL'),
-                h('input', {
-                  value: baseUrl,
-                  onChange: (ev) => setBaseUrl(ev.target.value),
-                  placeholder: 'https://api.example.com'
-                })
-            ),
-            h('label', {className: 'field'},
-                h('span', null, 'JWT token'),
-                h('input', {
-                  value: token,
-                  onChange: (ev) => setToken(ev.target.value),
-                  placeholder: 'Paste token from login'
-                })
+    return h('main', {className: 'page'},
+        h('h1', {className: 'title'}, 'JobsHunter'),
+        h('img', {src: 'images/JobsHunterLogo.svg', alt: 'JobsHunter logo', className: 'logo'}),
+        h('section', {className: 'card form-card'},
+            h('h2', null, 'Login to continue'),
+            h('form', {className: 'form', onSubmit: handleLogin},
+                h('label', {className: 'field'},
+                    h('span', null, 'Username'),
+                    h('input', {
+                      required: true,
+                      value: loginForm.username,
+                      onChange: (ev) => setLoginForm({...loginForm, username: ev.target.value})
+                    })
+                ),
+                h('label', {className: 'field'},
+                    h('span', null, 'Password'),
+                    h('input', {
+                      type: 'password',
+                      required: true,
+                      value: loginForm.password,
+                      onChange: (ev) => setLoginForm({...loginForm, password: ev.target.value})
+                    })
+                ),
+                h('button', {type: 'submit'}, 'Login')
             ),
             h('div', {className: 'status'}, `Status: ${status}`)
-        ),
-        h('div', {className: 'grid'},
-            h(Section, {title: 'Register'},
-                h('form', {className: 'form', onSubmit: handleRegister},
-                    h('label', {className: 'field'},
-                        h('span', null, 'Username'),
-                        h('input', {
-                          required: true,
-                          value: registerForm.username,
-                          onChange: (ev) => setRegisterForm({...registerForm, username: ev.target.value})
-                        })
-                    ),
-                    h('label', {className: 'field'},
-                        h('span', null, 'Email'),
-                        h('input', {
-                          type: 'email',
-                          required: true,
-                          value: registerForm.email,
-                          onChange: (ev) => setRegisterForm({...registerForm, email: ev.target.value})
-                        })
-                    ),
-                    h('label', {className: 'field'},
-                        h('span', null, 'Password'),
-                        h('input', {
-                          type: 'password',
-                          required: true,
-                          value: registerForm.password,
-                          onChange: (ev) => setRegisterForm({...registerForm, password: ev.target.value})
-                        })
-                    ),
-                    h('label', {className: 'field'},
-                        h('span', null, 'Phone'),
-                        h('input', {
-                          required: true,
-                          value: registerForm.phoneNumber,
-                          onChange: (ev) => setRegisterForm({...registerForm, phoneNumber: ev.target.value})
-                        })
-                    ),
-                    h('button', {type: 'submit'}, 'Register')
-                )
-            ),
-            h(Section, {title: 'Login'},
-                h('form', {className: 'form', onSubmit: handleLogin},
-                    h('label', {className: 'field'},
-                        h('span', null, 'Username'),
-                        h('input', {
-                          required: true,
-                          value: loginForm.username,
-                          onChange: (ev) => setLoginForm({...loginForm, username: ev.target.value})
-                        })
-                    ),
-                    h('label', {className: 'field'},
-                        h('span', null, 'Password'),
-                        h('input', {
-                          type: 'password',
-                          required: true,
-                          value: loginForm.password,
-                          onChange: (ev) => setLoginForm({...loginForm, password: ev.target.value})
-                        })
-                    ),
-                    h('button', {type: 'submit'}, 'Login')
-                )
-            )
-        ),
-        h('div', {className: 'grid'},
-            h(Section, {title: 'Profile'},
-                h('button', {onClick: handleMe, disabled: !token}, 'Load /me'),
-                h('pre', {className: 'response'}, me ? JSON.stringify(me, null, 2) : '-')
-            ),
-            h(Section, {title: 'Search jobs now'},
-                h('label', {className: 'checkbox'},
-                    h('input', {
-                      type: 'checkbox',
-                      checked: notifyWhatsApp,
-                      onChange: (ev) => setNotifyWhatsApp(ev.target.checked)
-                    }),
-                    'Notify on WhatsApp (if enabled for user)'
-                ),
-                h('button', {onClick: handleSearch, disabled: !token}, 'Search'),
-                h('pre', {className: 'response'}, jobs.length ? JSON.stringify(jobs, null, 2) : '-')
-            )
         )
     );
   };

--- a/application/src/main/resources/static/styles.css
+++ b/application/src/main/resources/static/styles.css
@@ -7,23 +7,25 @@ body {
   font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
   background: radial-gradient(circle at 20% 20%, #f6f9ff, #eef2ff 40%, #ffffff 70%);
   color: #1f2937;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .page {
-  max-width: 1100px;
+  width: min(480px, 100%);
   margin: 0 auto;
-  padding: 32px 20px 60px;
+  padding: 48px 20px 60px;
+  display: grid;
+  gap: 20px;
+  text-align: center;
 }
 
-header h1 {
-  margin: 0 0 6px;
-  font-size: 32px;
+.title {
+  margin: 0;
+  font-size: 36px;
   color: #111827;
-}
-
-header p {
-  margin: 0 0 18px;
-  color: #4b5563;
 }
 
 .card {
@@ -37,13 +39,6 @@ header p {
 .card h2 {
   margin: 0 0 12px;
   font-size: 20px;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 16px;
-  margin-top: 16px;
 }
 
 .form {
@@ -100,7 +95,7 @@ button:hover:not(:disabled) {
 }
 
 .status {
-  margin-top: 10px;
+  margin-top: 14px;
   padding: 10px 12px;
   background: #f3f4f6;
   border-radius: 10px;
@@ -108,21 +103,12 @@ button:hover:not(:disabled) {
   font-size: 14px;
 }
 
-.response {
-  margin-top: 12px;
-  background: #0b1221;
-  color: #e5e7eb;
-  padding: 12px;
-  border-radius: 10px;
-  min-height: 80px;
-  overflow: auto;
-  font-family: "SFMono-Regular", Consolas, Monaco, "Ubuntu Mono", monospace;
-  font-size: 13px;
+.logo {
+  width: 160px;
+  margin: 0 auto 8px;
+  display: block;
 }
 
-.checkbox {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
+.form-card {
+  text-align: left;
 }


### PR DESCRIPTION
## Summary
- simplify the frontend to a single-column login experience with centered title and logo
- update styling to center content and streamline form presentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694255c9313c832f8e6fc39ca3f6e403)