### PR TITLE
Improve user profile display and logo

### DIFF
--- a/application/src/main/resources/static/index.html
+++ b/application/src/main/resources/static/index.html
@@ -166,6 +166,43 @@
       background-color: #dc2626;
     }
 
+    .profile-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .profile-grid div {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 0.75rem;
+      word-break: break-word;
+    }
+
+    .profile-grid h3 {
+      margin: 0 0 0.35rem 0;
+      font-size: 0.95rem;
+      color: #111827;
+    }
+
+    .profile-grid p {
+      margin: 0;
+      color: #4b5563;
+      font-size: 0.9rem;
+    }
+
+    .code-block {
+      background: #0b1021;
+      color: #e5e7eb;
+      border-radius: 0.75rem;
+      padding: 1rem;
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      overflow: auto;
+      font-size: 0.9rem;
+      border: 1px solid #1f2937;
+    }
+
   </style>
 </head>
 <body>
@@ -263,16 +300,29 @@
       logMessage('Logged out.');
     };
 
+    const renderValue = (value) => {
+      if (value === null || value === undefined) return '—';
+      if (typeof value === 'object') return JSON.stringify(value);
+      return String(value);
+    };
+
+    const renderEntries = (obj) => Object.entries(obj || {}).map(([key, value]) =>
+      h('div', {key},
+        h('h3', null, key),
+        h('p', null, renderValue(value))
+      )
+    );
+
     // Helper component to display user profile information
     const UserProfile = () => {
       if (!user) return null;
 
       return h('section', {className: 'card profile-card'},
-        h('h2', null, `Welcome, ${user.username}!`),
-        h('div', {className: 'profile-info'},
-          h('p', null, h('strong', null, 'User ID:'), h('span', null, user.id)),
-          h('p', null, h('strong', null, 'Email:'), h('span', null, user.email || 'Not provided')),
-          h('p', null, h('strong', null, 'Role:'), h('span', {className: 'badge'}, user.role || 'GUEST')),
+        h('h2', null, `Welcome, ${user.username || 'User'}!`),
+        h('div', {className: 'profile-grid'}, renderEntries(user)),
+        h('div', null,
+          h('h3', {className: 'mt-4 mb-2 text-gray-800 font-semibold'}, 'Full response'),
+          h('pre', {className: 'code-block'}, JSON.stringify(user, null, 2))
         ),
         h('button', {
           onClick: handleLogout,
@@ -311,7 +361,7 @@
     return h('main', {className: 'page'},
       h('h1', {className: 'title'}, 'JobsHunter'),
 
-      h('img', {src: '/images/JobsHunterLogo.png', alt: 'JobsHunter logo', className: 'logo'}),
+      h('img', {src: 'images/JobsHunterLogo.png', alt: 'JobsHunter logo', className: 'logo'}),
 
       // Conditionally render the profile or the login form
       user ? h(UserProfile) : h(LoginForm),


### PR DESCRIPTION
## Summary
- display the full `/api/user/me` response in a formatted grid and raw JSON block
- add styling updates for the new profile layout
- load the JobsHunter logo using a relative path to ensure it renders

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942601963a4832fb553ec100fa070a7)