### PR TITLE
Adjust login input width

### DIFF
--- a/application/src/main/resources/static/index.html
+++ b/application/src/main/resources/static/index.html
@@ -80,6 +80,10 @@
       margin-bottom: 0.25rem;
     }
 
+    .auth-input {
+      width: 30%;
+    }
+
     input {
       padding: 0.75rem;
       border: 1px solid #d1d5db;
@@ -258,6 +262,7 @@
           h('label', {className: 'field'},
             h('span', null, 'Username'),
             h('input', {
+              className: 'auth-input',
               required: true,
               value: loginForm.username,
               onChange: (ev) => setLoginForm({...loginForm, username: ev.target.value})
@@ -267,6 +272,7 @@
             h('span', null, 'Password'),
             h('input', {
               type: 'password',
+              className: 'auth-input',
               required: true,
               value: loginForm.password,
               onChange: (ev) => setLoginForm({...loginForm, password: ev.target.value})


### PR DESCRIPTION
## Summary
- add a reusable auth-input style that sets login inputs to 30% width
- apply the new style to the username and password fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428ed24e50832f9bee5d72e84ed2e1)