### PR TITLE
Fix frontend build path for Maven

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -266,6 +266,9 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.15.0</version>
+                <configuration>
+                    <workingDirectory>${project.parent.basedir}</workingDirectory>
+                </configuration>
                 <executions>
                     <!-- 1. Install Node and npm -->
                     <execution>


### PR DESCRIPTION
## Summary
- configure the frontend-maven-plugin to run npm commands from the project root so Vite can find index.html during builds

## Testing
- not run (npm install blocked by registry restrictions in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452163e978832f8199be140c934567)